### PR TITLE
Deal with multiline properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@
 
     var hasRtl = hasDirectionCharacters(string, RTL);
     var hasLtr = hasDirectionCharacters(string, LTR);
-    
+ 
     if(hasRtl && hasLtr)
       return BIDI;
 
@@ -68,8 +68,8 @@
         hasLtr = false,
         hasDigit = false;
 
-    hasDigit = (sting.search(/[0-9]/) > -1);
-    
+    hasDigit = (string.search(/[0-9]/) > -1);
+
     // Remove white space and non directional characters
     string = string.replace(/[\s\n\0\f\t\v\'\"\-0-9\+\?\!]+/gm, '');
 
@@ -106,9 +106,9 @@
     }
 
     if(direction === RTL)
-      return hasRtl || (!hasLtr && hasDigit);
+      return hasRtl;
     if(direction === LTR)
-      return hasLtr;
+      return hasLtr || (!hasRtl && hasDigit);
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -2,9 +2,10 @@
 
   var LTR_MARK = "\u200e",
       RTL_MARK = "\u200f",
-      LTR = 'ltr',
-      RTL = 'rtl',
-      BIDI = 'bidi';
+      LTR = 'ltr', // Left to right direction content
+      RTL = 'rtl', // Right to left direction content
+      BIDI = 'bidi', // Both directions - any and all directions will not be ok
+      NODI = ''; // No direction - any and all directions are ok
 
   var rtlSciriptRanges = {
     Hebrew:   ["0590","05FF"],
@@ -23,42 +24,37 @@
   */
   function getDirection(string) {
 
-    if(typeof string === 'undefined'){
+    if(typeof string === 'undefined')
       throw new Error('TypeError missing argument');
-    }
 
-    if(typeof string !== 'string'){
+    if(typeof string !== 'string')
       throw new Error('TypeError getDirection expects strings');
-    }
 
-    if(string.indexOf(LTR_MARK) > -1 && string.indexOf(RTL_MARK) > -1) {
+    if(string === '')
+      return NODI;
+      
+    if(string.indexOf(LTR_MARK) > -1 && string.indexOf(RTL_MARK) > -1)
       return BIDI;
-    }
 
-    else if(string.indexOf(LTR_MARK) > -1) {
+    if(string.indexOf(LTR_MARK) > -1)
       return LTR;
-    }
 
-    else if(string.indexOf(RTL_MARK) > -1) {
+    if(string.indexOf(RTL_MARK) > -1)
       return RTL;
-    }
 
-    else if(hasDirectionCharacters(string, RTL) && hasDirectionCharacters(string, LTR)) {
+    var hasRtl = hasDirectionCharacters(string, RTL);
+    var hasLtr = hasDirectionCharacters(string, LTR);
+    
+    if(hasRtl && hasLtr)
       return BIDI;
-    }
 
-    else if(hasDirectionCharacters(string, LTR)) {
+    if(hasLtr)
       return LTR;
-    }
 
-    else if(hasDirectionCharacters(string, RTL)) {
+    if(hasRtl)
       return RTL;
-    }
 
-    else {
-      return LTR;
-    }
-
+    return NODI;
   }
   /**
    * Determine if a string has characters in right-to-left or left-to-right Unicode blocks
@@ -69,10 +65,13 @@
   function hasDirectionCharacters(string, direction) {
     var i, char, range, charIsRtl,
         hasRtl = false,
-        hasLtr = false;
+        hasLtr = false,
+        hasDigit = false;
 
+    hasDigit = (sting.search(/[0-9]/) > -1);
+    
     // Remove white space and non directional characters
-    string = string.replace(/\s+|\n|\0|\f|\t|\v|\'|\"/gm, '');
+    string = string.replace(/[\s\n\0\f\t\v\'\"\-0-9\+\?\!]+/gm, '');
 
     // Loop through each character
     for(i=0; i<string.length; i++) {
@@ -107,7 +106,7 @@
     }
 
     if(direction === RTL)
-      return hasRtl;
+      return hasRtl || (!hasLtr && hasDigit);
     if(direction === LTR)
       return hasLtr;
   }

--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@
     Tifinagh: ["2D30","2D7F"]
   };
 
-
   /*
    * Gets string direction
    * @param {string} - String to check for direction
@@ -72,8 +71,8 @@
         hasRtl = false,
         hasLtr = false;
 
-    // Remove white space
-    string = string.replace(/\s+/, '');
+    // Remove white space and non directional characters
+    string = string.replace(/\s+|\n|\0|\f|\t|\v|\'|\"/gm, '');
 
     // Loop through each character
     for(i=0; i<string.length; i++) {
@@ -84,7 +83,6 @@
 
       // Test each character against all ltr script ranges
       for (range in rtlSciriptRanges) {
-
 
         if (rtlSciriptRanges.hasOwnProperty(range)) {
 

--- a/string-direction-spec.js
+++ b/string-direction-spec.js
@@ -7,6 +7,7 @@
 
 var ltrText = 'Hello, world!',
     rtlText = 'سلام دنیا',
+    rtlMultilineText = 'שלום\nכיתה\nא\'',
     bidiText = 'Hello in Farsi is سلام',
     LTR_MARK = "\u200e",
     RTL_MARK = "\u200f";
@@ -70,6 +71,10 @@ describe('stringDirection', function(){
         expect(stringDirection.getDirection(rtlText)).toBe('rtl');
       });
 
+      it('should return "rtl" with rtl multiline variable', function(){
+        expect(stringDirection.getDirection(rtlMultilineText)).toBe('rtl');
+      });
+
       it('should return "bidi" with bidi variable', function(){
         expect(stringDirection.getDirection(bidiText)).toBe('bidi');
       });
@@ -78,7 +83,7 @@ describe('stringDirection', function(){
         expect(stringDirection.getDirection(LTR_MARK + ltrText)).toBe('ltr');
       });
 
-      it('should return "lte" with variables that has RTL mark', function(){
+      it('should return "ltr" with variables that has RTL mark', function(){
         expect(stringDirection.getDirection(RTL_MARK + ltrText)).toBe('rtl');
       });
 
@@ -99,8 +104,12 @@ describe('stringDirection', function(){
         expect(rtlText.getDirection()).toBe('rtl');
       });
 
+      it('should return "rtl" with rtl multiline variables', function(){
+        expect(rtlText.getDirection()).toBe('rtl');
+      });
+
       it('should return "bidi" with bidi variables', function(){
-        expect(bidiText.getDirection()).toBe('bidi');
+        expect(bidiMultilineText.getDirection()).toBe('bidi');
       });
 
       it('should return "ltr" with variables that has LTR mark', function(){

--- a/string-direction-spec.js
+++ b/string-direction-spec.js
@@ -5,12 +5,15 @@
     npm test
 */
 
-var ltrText = 'Hello, world!',
+var numberText = '1234',
+	ltrText = 'Hello, world!',
     rtlText = 'سلام دنیا',
+	ltrWithNumberText = '99 Bottles Of Bear...',
+	rtlWithNumberText = 'לקובע שלי 3 פינות',
     rtlMultilineText = 'שלום\nכיתה\nא\'',
     bidiText = 'Hello in Farsi is سلام',
-    LTR_MARK = "\u200e",
-    RTL_MARK = "\u200f";
+    LTR_MARK = '\u200e',
+    RTL_MARK = '\u200f';
 
 describe('stringDirection', function(){
   if(typeof require === 'function') {
@@ -63,12 +66,28 @@ describe('stringDirection', function(){
 
     describe('when passing string variables', function(){
 
+      it('should return "" with empty string variable', function(){
+        expect(stringDirection.getDirection('')).toBe('');
+      });
+
+      it('should return "ltr" with number variable', function(){
+        expect(stringDirection.getDirection(numberText)).toBe('ltr');
+      });
+
       it('should return "ltr" with ltr variable', function(){
         expect(stringDirection.getDirection(ltrText)).toBe('ltr');
       });
 
       it('should return "rtl" with rtl variable', function(){
         expect(stringDirection.getDirection(rtlText)).toBe('rtl');
+      });
+
+      it('should return "ltr" with ltr with number variable', function(){
+        expect(stringDirection.getDirection(ltrWithNumberText)).toBe('ltr');
+      });
+
+      it('should return "rtl" with rtl with number variable', function(){
+        expect(stringDirection.getDirection(rtlWithNumberText)).toBe('rtl');
       });
 
       it('should return "rtl" with rtl multiline variable', function(){
@@ -96,12 +115,28 @@ describe('stringDirection', function(){
 
     describe('when calling on string variables', function(){
 
+      it('should return "" with empty string variable', function(){
+        expect(''.getDirection()).toBe('');
+      });
+
+      it('should return "ltr" with number variable', function(){
+        expect(numberText.getDirection()).toBe('ltr');
+      });
+
       it('should return "ltr" with ltr variables', function(){
         expect(ltrText.getDirection()).toBe('ltr');
       });
 
       it('should return "rtl" with rtl variables', function(){
         expect(rtlText.getDirection()).toBe('rtl');
+      });
+
+      it('should return "ltr" with ltr with number variable', function(){
+        expect(ltrWithNumberText.getDirection()).toBe('ltr');
+      });
+
+      it('should return "rtl" with rtl with number variable', function(){
+        expect(rtlWithNumberText.getDirection()).toBe('rtl');
       });
 
       it('should return "rtl" with rtl multiline variables', function(){
@@ -113,7 +148,7 @@ describe('stringDirection', function(){
       });
 
       it('should return "ltr" with variables that has LTR mark', function(){
-        expect((LTR_MARK + ltrText).getDirection()).toBe('ltr');
+        expect((LTR_MARK + rtlText).getDirection()).toBe('ltr');
       });
 
       it('should return "ltr" with variables that has RTL mark', function(){

--- a/string-direction-spec.js
+++ b/string-direction-spec.js
@@ -107,7 +107,7 @@ describe('stringDirection', function(){
         expect((LTR_MARK + ltrText).getDirection()).toBe('ltr');
       });
 
-      it('should return "lte" with variables that has RTL mark', function(){
+      it('should return "ltr" with variables that has RTL mark', function(){
         expect((RTL_MARK + ltrText).getDirection()).toBe('rtl');
       });
 

--- a/string-direction-spec.js
+++ b/string-direction-spec.js
@@ -105,11 +105,11 @@ describe('stringDirection', function(){
       });
 
       it('should return "rtl" with rtl multiline variables', function(){
-        expect(rtlText.getDirection()).toBe('rtl');
+        expect(rtlMultilineText.getDirection()).toBe('rtl');
       });
 
       it('should return "bidi" with bidi variables', function(){
-        expect(bidiMultilineText.getDirection()).toBe('bidi');
+        expect(bidiText.getDirection()).toBe('bidi');
       });
 
       it('should return "ltr" with variables that has LTR mark', function(){


### PR DESCRIPTION
The original code treated whitespaces and non directional characters like comma as ltr characters and resulted in recognizing strings that contained those characters or multiple lines as, and only rtl characters as bidi strings
